### PR TITLE
v0.3.2-revB

### DIFF
--- a/Komodo/Assets/Packages/KomodoCore/README.md
+++ b/Komodo/Assets/Packages/KomodoCore/README.md
@@ -1,8 +1,76 @@
-Change relay.js so that API_BASE_URL and RELAY_BASE_URL point to your own komodo-portal and komodo-relay deployments.
+[![openupm](https://img.shields.io/npm/v/com.graingeridealab.komodo?label=openupm&registry_uri=https://package.openupm.com)](https://openupm.com/packages/com.graingeridealab.komodo/)
 
-If you are developing on the University of Illinois campus, please contact idealab@library.illinois.edu to request access to the Komodo development server connection credentials.
+# Installation
 
-# Attributions
+**Install Unity.** If it’s not already installed, install Unity version 2020.x. Make sure to check the box for WebGL Build Support.
+
+**Create a WebGL Project.** Create a new Unity project, version 2020.x, type 3D, name `[YourProjectName]`. Choose File > Build Settings. Choose `WebGL` under `Platform`. Select `Switch Platform`.
+
+**Add Scoped Registries to `manifest.json`.** In File Explorer, open `[YourProjectName] > Packages > manifest.json`.
+
+Edit the file to add the following two scoped registries: 
+
+    { // this is the beginning of manifest.json  
+      "scopedRegistries": [
+        {
+          "name": "Packages from jillejr",
+          "url": "https://npm.cloudsmith.io/jillejr/newtonsoft-json-for-unity/",
+          "scopes": [
+            "jillejr"
+          ]
+        },
+        {
+          "name": "OpenUPM",
+          "url": "https://package.openupm.com",
+          "scopes": [
+            "com.de-panther",
+            "com.atteneder",
+            "com.graingeridealab"
+          ]
+        }
+      ],
+      "dependencies": {
+        //... (these are dependencies that are already in the file)
+      }
+    } // this is the end of manifest.json
+
+JSON does not support comments, so take out all  `//` and everything after them. [1]
+
+Save the file and return to the Unity Editor. Unity should alert you that two new scoped registries are available. [2]
+
+**Install KomodoCore.** In the Unity Editor main window, choose `Window > Package Manager`. Click the  `[ Packages: In Project v ]` (the second dropdown) in the upper left. Look for the entry GELIC-IDEALab > KomodoCore. Select `Install`. Wait for the package to be loaded, then skip to “Add Scenes.” This method of installing KomodoCore uses OpenUPM, but there are two alternative installation methods. [3]
+
+**Copy WebGLTemplates.** Select Window > Komodo > Copy WebGLTemplates. In the Project window, there should now be a folder under Assets titled “WebGLTemplates.” 
+
+**Add Scenes.** Go to File > Build Settings. Add `Packages/KomodoCore/KomodoCoreAssets/Scenes/Main` and `Packages/KomodoCore/KomodoCoreAssets/Scenes/Outdoors/Outdoors` to `Scenes in Build`.
+
+**Select the Komodo WebXR Template.** While still in the `Build Settings` window, choose `Player Settings…`. Make sure the tab selected is the WebGL icon. Expand the `Resolution and Presentation` panel. Select `KomodoWebXRFullView` in the WebGL templates option. [4]
+
+**Test the project.** Press `[ > ]` (the play button at the center top of the Unity Editor). Check the console for errors. If it runs without errors, congratulations!
+
+**Develop a module with KomodoCore**. Follow the Guide to Developing Modules with Komodo. [6]
+
+##  Footnotes
+
+1. If for some reason the above is not up-to-date, the latest version of the scoped registries can always be found in the development repository — `komodo-unity/Komodo/Packages/manifest.json`.
+
+2. If not, go to `Edit > Project Settings > Package Manager > Scoped Registries` and check to see that `Packages from jillejr` and `OpenUPM` are listed and reflect the structure of `manifest.json`.
+
+3. Alternative install methods: 
+
+    1. If you have downloaded the Komodo package manually
+    Click `[` `+` `v ]` (the plus-button dropdown) in the upper left. Choose `Add package from disk…` Find and select `[KomodoPackageLocation]/KomodoCore/package.json`. Wait for the package to be loaded, then skip to “Add Scenes.”
+    
+    1. If you have downloaded or cloned the komodo-unity repository
+    Click `[` `+` `v ]` (the plus-button dropdown) in the upper left. Choose `Add package from disk…`. Find and select `komodo-unity/Komodo/Assets/Packages/KomodoCore/package.json`. Wait for the package to be loaded, then skip to “Add Scenes.”
+
+4. If you only see `Default` and `Minimal` as options, the WebGLTemplates folder did not copy properly. 
+
+5. TODO — add Unity manual link here. 
+
+6. TODO — add link to this guide, which will detail how to perform Unity-level changes, Configuration- and Extension-level changes, and Package-level changes to the Komodo project. Until then, know that when you are using Komodo with your own server, you should change relay.js so that API_BASE_URL and RELAY_BASE_URL point to your own komodo-portal and komodo-relay deployments. If you are developing on the University of Illinois campus, please contact idealab@library.illinois.edu to request access to the Komodo development server connection credentials.
+
+# Licenses and Attributions
 
 Komodo Astronaut is remixed from <a href="https://poly.google.com/view/dLHpzNdygsg">Astronaut</a> by <a href="https://poly.google.com/user/4aEd8rQgKu2">Poly by Google</a> and licensed under <a href="https://creativecommons.org/licenses/by/3.0/legalcode">CC-BY 3.0.</a>
 
@@ -29,117 +97,3 @@ Contains [Tiles084](ambientCG.com/a/Tiles084) from [AmbientCG.com](https://help.
 [vpenades / SharpGLTF](https://github.com/vpenades/SharpGLTF) is licensed under the [MIT License](https://github.com/vpenades/SharpGLTF/blob/master/LICENSE).
 
 [SixLabors / ImageSharp](https://github.com/SixLabors/ImageSharp) is licensed under the [Apache License 2.0](https://github.com/SixLabors/ImageSharp/blob/master/LICENSE).
-
-___
-*The rest of these instructions are partially correct and incomplete as of 2021-05-07. Our apologies.*
-___
-
-## Installing the komodo_unity Core
-
-**Clone the repository.** 
-
-Open a bash terminal and run `git clone https://gitlab.engr.illinois.edu/dev-studio/komodo/komodo_unity`, or download a release ZIP from the [Releases](https://gitlab.engr.illinois.edu/dev-studio/komodo/komodo_unity/-/releases/) page. 
-
-**Add the project to your Unity Hub and open it.**
-
-Open Unity Hub. Make sure the Projects tab is open. At the top right of the screen, press “Add.” When the folder selection window opens, choose the  `… > komodo_unity > Komodo` folder. Click the dropdown to choose a variant of Unity 2018.4 LTS, or install one if you don’t have 2018.4. Then click the project name to open it. 
-
-**Download and open the main scene.** 
-
-Download the main scene from the same page that you got the release from, or visit the [Komodo Releases folder](https://uofi.box.com/s/gsrtdj8bfyxet3gssnefif8d30cpvpk6) and download vX.Y.Z.unity
-
-Import the scene file into the `… > Assets > Scenes` folder with the name “<name>” by drag-and-dropping it into Unity or right-clicking inside the `Scenes` folder and choosing `Import New Asset…`. Double-click to open it, or use File > Open Scene.
-
-**Test your installation in the editor.**
-
-Enter Play Mode by pressing the play button at the center top of the Unity window. 
-
-Open the Console to make sure there are no warnings or errors. You may need to use the filters to enable the display of warnings and errors. 
-Learn how to Enable VR Support in Play Mode. [1] 
-
-You may develop for Komodo without using VR in Play Mode, but you will need to build each time you need to test VR-specific interactions.
-
-**[1]** **Enable VR Support in Play Mode**
-
-For convenience, the Komodo SDK supports VR in Unity Play Mode. This allows you to test non-networked interaction without building, as long as you have a VR headset that functions. 
-
-You will need the appropriate SDK to use Unity with the headset, which is usually provided by the headset manufacturer. 
-
-Currently, only the Oculus Rift CV1, Rift S, and Quest 1 and 2 (via Oculus Link) are officially supported. And only Oculus Touch v2 inputs are fully supported by the unmodified SDK, but you may provide your own input mapping. [3]
-
-Install the [Oculus Desktop](https://docs.unity3d.com/Packages/com.unity.xr.oculus.standalone@1.38/manual/index.html) package in Unity. 
-Ensure that your Oculus headset is set up and that the Oculus app is running on your PC.
-
-## Running komodo_unity in the Browser (Non-networked)
-
-To test with networking, install komodo_relay and read “Running komodo_unity with komodo_relay”. 
-
-**Test your installation in the browser by building.**
-
-Make sure you are following our recommended project settings. [2]
-
-If you have not made any modifications to the scene, press Build and Run. 
-
-Read more about using Komodo with our provided host-it-yourself relay server. [4]
-
-**Serve the contents of the build folder**
-
-This method requires having a Bash terminal and having NodeJS installed and in your path. 
-
-`cd …/<build-folder-name>/`
-
-`npx serve .`
-
-**Connect to the build folder in the browser** 
-
-Open a browser compatible with WebXR and your headset runtime. 
-
-Go to `localhost:5000`.
-
-Wait for the page to load
-
-Press the goggles button to enter VR.
-
-**[2]** **Recommended Project Settings**
-
-Coming soon. 
-
-**[3]** **Custom Input Mappings**
-
-Coming soon.
-
-## Making Basic Modifications to `komodo_unity`
-
-Out-of-the-Box Features
-
-(TODO: “If using Komodo core, you can make modifications to everything EXCEPT…”)
-
-Coming soon. 
-
-Modifying the Base Scene
-
-Coming soon. 
-
-Adding More Scenes
-
-Coming soon.
-
-## Developing Modules with `komodo_unity`
-
-Networking Components
-
-Coming soon. 
-
-Custom Interactions: Simple Example
-
-Coming soon. 
-
-Custom Interactions: Complex Example
-
-Coming soon. 
-
-See also: Modifying Scenes, Adding More Scenes
-
-## Further Reading
-
-To test with networking, install komodo_relay and read “Running komodo_unity with komodo_relay”. 

--- a/README.md
+++ b/README.md
@@ -1,112 +1,72 @@
 [![openupm](https://img.shields.io/npm/v/com.graingeridealab.komodo?label=openupm&registry_uri=https://package.openupm.com)](https://openupm.com/packages/com.graingeridealab.komodo/)
 
-## Installing the komodo_unity Core
+## Installation
 
-**Clone the repository.** 
+**Install Unity.** If it’s not already installed, install Unity version 2020.x. Make sure to check the box for WebGL Build Support.
 
-Open a bash terminal and run `git clone https://gitlab.engr.illinois.edu/dev-studio/komodo/komodo_unity`, or download a release ZIP from the [Releases](https://gitlab.engr.illinois.edu/dev-studio/komodo/komodo_unity/-/releases/) page. 
+**Create a WebGL Project.** Create a new Unity project, version 2020.x, type 3D, name `[YourProjectName]`. Choose File > Build Settings. Choose `WebGL` under `Platform`. Select `Switch Platform`.
 
-**Add the project to your Unity Hub and open it.**
+**Add Scoped Registries to `manifest.json`.** In File Explorer, open `[YourProjectName] > Packages > manifest.json`.
 
-Open Unity Hub. Make sure the Projects tab is open. At the top right of the screen, press “Add.” When the folder selection window opens, choose the  `… > komodo_unity > Komodo` folder. Click the dropdown to choose a variant of Unity 2018.4 LTS, or install one if you don’t have 2018.4. Then click the project name to open it. 
+Edit the file to add the following two scoped registries: 
 
-**Download and open the main scene.** 
+    { // this is the beginning of manifest.json  
+      "scopedRegistries": [
+        {
+          "name": "Packages from jillejr",
+          "url": "https://npm.cloudsmith.io/jillejr/newtonsoft-json-for-unity/",
+          "scopes": [
+            "jillejr"
+          ]
+        },
+        {
+          "name": "OpenUPM",
+          "url": "https://package.openupm.com",
+          "scopes": [
+            "com.de-panther",
+            "com.atteneder",
+            "com.graingeridealab"
+          ]
+        }
+      ],
+      "dependencies": {
+        //... (these are dependencies that are already in the file)
+      }
+    } // this is the end of manifest.json
 
-Download the main scene from the same page that you got the release from, or visit the [Komodo Releases folder](https://uofi.box.com/s/gsrtdj8bfyxet3gssnefif8d30cpvpk6) and download vX.Y.Z.unity
+JSON does not support comments, so take out all  `//` and everything after them. [1]
 
-Import the scene file into the `… > Assets > Scenes` folder with the name “<name>” by drag-and-dropping it into Unity or right-clicking inside the `Scenes` folder and choosing `Import New Asset…`. Double-click to open it, or use File > Open Scene.
+Save the file and return to the Unity Editor. Unity should alert you that two new scoped registries are available. [2]
 
-**Test your installation in the editor.**
+**Install KomodoCore.** In the Unity Editor main window, choose `Window > Package Manager`. Click the  `[ Packages: In Project v ]` (the second dropdown) in the upper left. Look for the entry GELIC-IDEALab > KomodoCore. Select `Install`. Wait for the package to be loaded, then skip to “Add Scenes.” This method of installing KomodoCore uses OpenUPM, but there are two alternative installation methods. [3]
 
-Enter Play Mode by pressing the play button at the center top of the Unity window. 
+**Copy WebGLTemplates.** Select Window > Komodo > Copy WebGLTemplates. In the Project window, there should now be a folder under Assets titled “WebGLTemplates.” 
 
-Open the Console to make sure there are no warnings or errors. You may need to use the filters to enable the display of warnings and errors. 
-Learn how to Enable VR Support in Play Mode. [1] 
+**Add Scenes.** Go to File > Build Settings. Add `Packages/KomodoCore/KomodoCoreAssets/Scenes/Main` and `Packages/KomodoCore/KomodoCoreAssets/Scenes/Outdoors/Outdoors` to `Scenes in Build`.
 
-You may develop for Komodo without using VR in Play Mode, but you will need to build each time you need to test VR-specific interactions.
+**Select the Komodo WebXR Template.** While still in the `Build Settings` window, choose `Player Settings…`. Make sure the tab selected is the WebGL icon. Expand the `Resolution and Presentation` panel. Select `KomodoWebXRFullView` in the WebGL templates option. [4]
 
-**[1]** **Enable VR Support in Play Mode**
+**Test the project.** Press `[ > ]` (the play button at the center top of the Unity Editor). Check the console for errors. If it runs without errors, congratulations!
 
-For convenience, the Komodo SDK supports VR in Unity Play Mode. This allows you to test non-networked interaction without building, as long as you have a VR headset that functions. 
+**Develop a module with KomodoCore**. Follow the Guide to Developing Modules with Komodo. [6]
 
-You will need the appropriate SDK to use Unity with the headset, which is usually provided by the headset manufacturer. 
 
-Currently, only the Oculus Rift CV1, Rift S, and Quest 1 and 2 (via Oculus Link) are officially supported. And only Oculus Touch v2 inputs are fully supported by the unmodified SDK, but you may provide your own input mapping. [3]
+##  Footnotes
 
-Install the [Oculus Desktop](https://docs.unity3d.com/Packages/com.unity.xr.oculus.standalone@1.38/manual/index.html) package in Unity. 
-Ensure that your Oculus headset is set up and that the Oculus app is running on your PC.
+1. If for some reason the above is not up-to-date, the latest version of the scoped registries can always be found in the development repository — `komodo-unity/Komodo/Packages/manifest.json`.
 
-## Running komodo_unity in the Browser (Non-networked)
+2. If not, go to `Edit > Project Settings > Package Manager > Scoped Registries` and check to see that `Packages from jillejr` and `OpenUPM` are listed and reflect the structure of `manifest.json`.
 
-To test with networking, install komodo_relay and read “Running komodo_unity with komodo_relay”. 
+3. Alternative install methods: 
 
-**Test your installation in the browser by building.**
+    1. If you have downloaded the Komodo package manually
+    Click `[` `+` `v ]` (the plus-button dropdown) in the upper left. Choose `Add package from disk…` Find and select `[KomodoPackageLocation]/KomodoCore/package.json`. Wait for the package to be loaded, then skip to “Add Scenes.”
+    
+    1. If you have downloaded or cloned the komodo-unity repository
+    Click `[` `+` `v ]` (the plus-button dropdown) in the upper left. Choose `Add package from disk…`. Find and select `komodo-unity/Komodo/Assets/Packages/KomodoCore/package.json`. Wait for the package to be loaded, then skip to “Add Scenes.”
 
-Make sure you are following our recommended project settings. [2]
+4. If you only see `Default` and `Minimal` as options, the WebGLTemplates folder did not copy properly. 
 
-If you have not made any modifications to the scene, press Build and Run. 
+5. TODO — add Unity manual link here. 
 
-Read more about using Komodo with our provided host-it-yourself relay server. [4]
-
-**Serve the contents of the build folder**
-
-This method requires having a Bash terminal and having NodeJS installed and in your path. 
-
-`cd …/<build-folder-name>/`
-
-`npx serve .`
-
-**Connect to the build folder in the browser** 
-
-Open a browser compatible with WebXR and your headset runtime. 
-
-Go to `localhost:5000`.
-
-Wait for the page to load
-
-Press the goggles button to enter VR.
-
-**[2]** **Recommended Project Settings**
-
-Coming soon. 
-
-**[3]** **Custom Input Mappings**
-
-Coming soon.
-
-## Making Basic Modifications to `komodo_unity`
-
-Out-of-the-Box Features
-
-(TODO: “If using Komodo core, you can make modifications to everything EXCEPT…”)
-
-Coming soon. 
-
-Modifying the Base Scene
-
-Coming soon. 
-
-Adding More Scenes
-
-Coming soon.
-
-## Developing Modules with `komodo_unity`
-
-Networking Components
-
-Coming soon. 
-
-Custom Interactions: Simple Example
-
-Coming soon. 
-
-Custom Interactions: Complex Example
-
-Coming soon. 
-
-See also: Modifying Scenes, Adding More Scenes
-
-## Further Reading
-
-To test with networking, install komodo_relay and read “Running komodo_unity with komodo_relay”. 
-
+6. TODO — add link to this guide, which will detail how to perform Unity-level changes, Configuration- and Extension-level changes, and Package-level changes to the Komodo project. 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![openupm](https://img.shields.io/npm/v/com.graingeridealab.komodo?label=openupm&registry_uri=https://package.openupm.com)](https://openupm.com/packages/com.graingeridealab.komodo/)
+
 ## Installing the komodo_unity Core
 
 **Clone the repository.** 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![openupm](https://img.shields.io/npm/v/com.graingeridealab.komodo?label=openupm&registry_uri=https://package.openupm.com)](https://openupm.com/packages/com.graingeridealab.komodo/)
 
-## Installation
+# Installation
 
 **Install Unity.** If it’s not already installed, install Unity version 2020.x. Make sure to check the box for WebGL Build Support.
 
@@ -50,7 +50,6 @@ Save the file and return to the Unity Editor. Unity should alert you that two ne
 
 **Develop a module with KomodoCore**. Follow the Guide to Developing Modules with Komodo. [6]
 
-
 ##  Footnotes
 
 1. If for some reason the above is not up-to-date, the latest version of the scoped registries can always be found in the development repository — `komodo-unity/Komodo/Packages/manifest.json`.
@@ -69,4 +68,32 @@ Save the file and return to the Unity Editor. Unity should alert you that two ne
 
 5. TODO — add Unity manual link here. 
 
-6. TODO — add link to this guide, which will detail how to perform Unity-level changes, Configuration- and Extension-level changes, and Package-level changes to the Komodo project. 
+6. TODO — add link to this guide, which will detail how to perform Unity-level changes, Configuration- and Extension-level changes, and Package-level changes to the Komodo project. Until then, know that when you are using Komodo with your own server, you should change relay.js so that API_BASE_URL and RELAY_BASE_URL point to your own komodo-portal and komodo-relay deployments. If you are developing on the University of Illinois campus, please contact idealab@library.illinois.edu to request access to the Komodo development server connection credentials.
+
+# Licenses and Attributions
+
+Komodo Astronaut is remixed from <a href="https://poly.google.com/view/dLHpzNdygsg">Astronaut</a> by <a href="https://poly.google.com/user/4aEd8rQgKu2">Poly by Google</a> and licensed under <a href="https://creativecommons.org/licenses/by/3.0/legalcode">CC-BY 3.0.</a>
+
+<a href="https://assetstore.unity.com/packages/3d/vegetation/trees/low-poly-trees-pack-73954#description">Low Poly Trees - Pack</a> by <a href="https://www.lmhpoly.com/">LMHPOLY</a> is licensed under <a href="https://www.mediafire.com/file/ejr7fqerjftpfyt/License.pdf/file">a custom license</a>.
+
+[VR UI Kit: Material Design System](https://assetstore.unity.com/packages/tools/gui/vr-ui-kit-material-design-system-135769#content) by [Space Bear, Inc](https://spacebearinc.com/): the license can be found in `<projectLocation>\Packages\KomodoCore\KomodoCoreAssets\Text\Fonts - VRUI - Material Design\Roboto\LICENSE.txt` or [here](https://github.com/gelic-idealab/komodo-unity/blob/master/Komodo/Assets/Packages/KomodoCore/Samples~/KomodoCoreAssets/Text/Fonts%20-%20VRUI%20-%20Material%20Design/Roboto/LICENSE.txt).
+
+[WorldSkies Free Skybox Pack](https://assetstore.unity.com/packages/2d/textures-materials/sky/worldskies-free-skybox-pack-86517#description) is by [PULSAR BYTES](https://www.pulsarbytes.com/).
+
+Sandpaper is from [Toptal Subtle Patterns](https://subtlepatterns.com)
+
+Contains [Tiles084](ambientCG.com/a/Tiles084) from [AmbientCG.com](https://help.ambientcg.com/01-General/Licensing.html), licensed under [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).
+
+[De-Panther / unity-webxr-export](https://github.com/De-Panther/unity-webxr-export/) is licensed under the [Apache License 2.0](https://github.com/De-Panther/unity-webxr-export/blob/master/LICENSE).
+
+[atteneder / glTFast](https://github.com/atteneder/glTFast) is licensed under the [Apache License 2.0](https://github.com/atteneder/glTFast/blob/main/LICENSE.md).
+
+[Siccity / GLTFUtility](https://github.com/Siccity/GLTFUtility) is licensed under the [MIT License](https://github.com/Siccity/GLTFUtility/blob/master/LICENSE.md).
+
+[googlevr / tilt-brush-toolkit](https://github.com/googlevr/tilt-brush-toolkit/) is licensed under the [Apache License 2.0](https://github.com/googlevr/tilt-brush-toolkit/blob/master/LICENSE).
+
+[socketio / socketio](https://github.com/socketio/socket.io) is licensed under the [MIT License](https://github.com/socketio/socket.io/blob/master/LICENSE).
+
+[vpenades / SharpGLTF](https://github.com/vpenades/SharpGLTF) is licensed under the [MIT License](https://github.com/vpenades/SharpGLTF/blob/master/LICENSE).
+
+[SixLabors / ImageSharp](https://github.com/SixLabors/ImageSharp) is licensed under the [Apache License 2.0](https://github.com/SixLabors/ImageSharp/blob/master/LICENSE).


### PR DESCRIPTION
Updated GitHub README to include the latest installation instructions, licenses and attributions, and an OpenUPM badge.  Updated OpenUPM README to include the latest installation instructions and an OpenUPM badge. Removed legacy documentation. Note: it seems that the GitHub README is the one used by OpenUPM. 