### PR TITLE
Hotfix/sync vs socket 

### DIFF
--- a/Komodo/Assets/Packages/KomodoCore/Hidden~/WebGLTemplates/KomodoWebXRFullView2020/relay.js
+++ b/Komodo/Assets/Packages/KomodoCore/Hidden~/WebGLTemplates/KomodoWebXRFullView2020/relay.js
@@ -1,8 +1,10 @@
 // 'esversion: 6'
 
-// Replace these with your own server's URLs.
+// Remember: also change Assets\Packages\KomodoCore\Hidden~\WebGLTemplates\KomodoWebXRFullView2020\relay.js
 
 // Tip: if you need to change this on-the-fly, you can edit this file without rebuilding. It's also possible to use the inspector to inspect the VR frame and call `window.RELAY_API_BASE_URL="<your-server-url>"`, if for some reason you need to do that in real time.
+
+// Replace these with your own server's URLs.
 
 var RELAY_BASE_URL = "http://localhost:3000";
 var API_BASE_URL = "http://localhost:4040";
@@ -33,8 +35,6 @@ var getParams = function (url) {
 };
 
 var params = getParams(window.location.href);
-
-console.log(params);
 
 // Removes everything after the "?" in the input string.
 var removeQuery = function (url) {
@@ -120,7 +120,6 @@ request.send();
 
 request.onload = function(){
     let res = request.response;
-    console.log(res);
 
     // session details
     details.build = runtimeAppAndBuild;

--- a/Komodo/Assets/Packages/KomodoCore/KomodoCoreAssets/Plugins/jslib/socket-funcs.jslib
+++ b/Komodo/Assets/Packages/KomodoCore/KomodoCoreAssets/Plugins/jslib/socket-funcs.jslib
@@ -54,7 +54,7 @@
 
         window.socketIODebugInfo.relayBaseURL = window.RELAY_BASE_URL;
 
-        console.log("====== sync ======:", socket);
+        console.log("====== sync ======:", window.sync);
 
         return 0;
     },
@@ -309,9 +309,7 @@
         });
 
         window.sync.on('captureStarted', function() {
-
             window.gameInstance.SendMessage(socketIOAdapter, 'OnCaptureStarted');
-            
         });
         
         // Perform actions when the user closes the tab

--- a/Komodo/Assets/Packages/KomodoCore/package.json
+++ b/Komodo/Assets/Packages/KomodoCore/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.graingeridealab.komodo",
     "displayName": "KomodoCore",
-    "version": "0.5.6-revA",
+    "version": "0.5.6-revB",
     "unity": "2020.3",
     "keywords": [
     "webxr",

--- a/Komodo/Assets/WebGLTemplates/KomodoWebXRFullView2020/relay.js
+++ b/Komodo/Assets/WebGLTemplates/KomodoWebXRFullView2020/relay.js
@@ -2,14 +2,17 @@
 
 // Replace these with your own server's URLs.
 
+// Remember: also change Assets\WebGLTemplates\KomodoWebXRFullView2020\relay.js
 // Tip: if you need to change this on-the-fly, you can edit this file without rebuilding. It's also possible to use the inspector to inspect the VR frame and call `window.RELAY_API_BASE_URL="<your-server-url>"`, if for some reason you need to do that in real time.
+
+// Replace these with your own server's URLs.
 
 var RELAY_BASE_URL = "http://localhost:3000";
 var API_BASE_URL = "http://localhost:4040";
-var VR_BASE_URL = "http://localhost:9999"; //TODO -- change this to a better default
+var VR_BASE_URL = "http://localhost:8123"; //TODO -- change this to a better default
 
 // init globals which Unity will assign when setup is done.
-var socket = null;
+var sync = null;
 var chat = null;
 
 /**


### PR DESCRIPTION
# Hotfix/sync vs socket 

Target: v0.5.6-revB

The WebGLTemplates's relay.js that are available in the Package's ~Hidden folder mismatched the WebGLTemplates's relay.js at the top level of this repository's assets, meaning that any package that depends on this would throw an error during SetSyncEventListeners. This hotfix repairs the bug. If you use the Komodo package, be sure to go to Window > KomodoCore > Copy WebGLTemplates to fix your socket-funcs.jslib.