### PR TITLE
added messages for the following interaction types:

### DIFF
--- a/Komodo/Assets/Packages/KomodoCore/Runtime/Prefabs/MenuUI.prefab
+++ b/Komodo/Assets/Packages/KomodoCore/Runtime/Prefabs/MenuUI.prefab
@@ -11819,6 +11819,10 @@ MonoBehaviour:
   brushToggle: {fileID: 5720538800747667725}
   leaveAndRejoinButton: {fileID: 5790234758553503690}
   closeConnectionAndRejoinButton: {fileID: 2411945462265822991}
+  settingsTab: {fileID: 3915486095905569679}
+  peopleTab: {fileID: 6688689522628545538}
+  interactTab: {fileID: 8928291943553237011}
+  createTab: {fileID: 4882718586060955810}
 --- !u!114 &4193681595172214892
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Komodo/Assets/Packages/KomodoCore/Runtime/Scripts/RuntimeSession/ClientSpawnManager.cs
+++ b/Komodo/Assets/Packages/KomodoCore/Runtime/Scripts/RuntimeSession/ClientSpawnManager.cs
@@ -98,7 +98,13 @@ namespace Komodo.Runtime
         UNLOCK = 9,
         LINE = 10,
         LINE_END = 11,
+        SHOW_MENU = 12,
+        HIDE_MENU = 13,
 
+        SETTING_TAB = 14,
+        PEOPLE_TAB = 15,
+        INTERACTION_TAB = 16,
+        CREATE_TAB = 17,
     }
     #endregion
     /// <summary>
@@ -1180,6 +1186,17 @@ namespace Komodo.Runtime
             location.z = Mathf.Cos(Mathf.Deg2Rad * degrees);
             location.z *= spreadRadius;
             return location;
+        }
+
+        public void SendMenuInteractionsType(int interaction) {
+            NetworkUpdateHandler.Instance.SendSyncInteractionMessage (new Interaction 
+            {
+                sourceEntity_id = NetworkUpdateHandler.Instance.client_id,
+
+                interactionType = interaction,
+
+                targetEntity_id = 0,
+            });
         }
 
         #endregion

--- a/Komodo/Assets/Packages/KomodoCore/Runtime/Scripts/RuntimeSession/KomodoMenu.cs
+++ b/Komodo/Assets/Packages/KomodoCore/Runtime/Scripts/RuntimeSession/KomodoMenu.cs
@@ -20,7 +20,14 @@ namespace Komodo.Runtime
         public Button leaveAndRejoinButton;
 
         public Button closeConnectionAndRejoinButton;
+        
+        public TabButton settingsTab;
 
+        public TabButton peopleTab;
+
+        public TabButton interactTab;
+
+        public TabButton createTab;
 
         void OnValidate ()
         {
@@ -110,6 +117,26 @@ namespace Komodo.Runtime
             closeConnectionAndRejoinButton.onClick.AddListener(() =>
             {
                 KomodoEventManager.TriggerEvent("connection.closeConnectionAndRejoin");
+            });
+
+            settingsTab.onTabSelected.AddListener(() => 
+            {
+                ClientSpawnManager.Instance.SendMenuInteractionsType((int)INTERACTIONS.SETTING_TAB);
+            });
+
+            peopleTab.onTabSelected.AddListener(() => 
+            {
+                ClientSpawnManager.Instance.SendMenuInteractionsType((int)INTERACTIONS.PEOPLE_TAB);
+            });
+
+            interactTab.onTabSelected.AddListener(() => 
+            {
+                ClientSpawnManager.Instance.SendMenuInteractionsType((int)INTERACTIONS.INTERACTION_TAB);
+            });
+
+            createTab.onTabSelected.AddListener(() => 
+            {
+                ClientSpawnManager.Instance.SendMenuInteractionsType((int)INTERACTIONS.CREATE_TAB);
             });
         }
 

--- a/Komodo/Assets/Packages/KomodoCore/Runtime/Scripts/RuntimeSession/Managers/UIManager.cs
+++ b/Komodo/Assets/Packages/KomodoCore/Runtime/Scripts/RuntimeSession/Managers/UIManager.cs
@@ -240,6 +240,33 @@ namespace Komodo.Runtime
             gObject.SetActive(doShow);
         }
 
+        public void SendMenuVisibilityUpdate(bool visibility) {
+
+            if (visibility) 
+            {
+                NetworkUpdateHandler.Instance.SendSyncInteractionMessage (new Interaction 
+                {
+
+                sourceEntity_id = NetworkUpdateHandler.Instance.client_id,
+
+                interactionType = (int)INTERACTIONS.SHOW_MENU,
+
+                targetEntity_id = 0,
+                });
+
+            } else {
+                NetworkUpdateHandler.Instance.SendSyncInteractionMessage (new Interaction 
+                {
+
+                sourceEntity_id = NetworkUpdateHandler.Instance.client_id,
+
+                interactionType = (int)INTERACTIONS.HIDE_MENU,
+
+                targetEntity_id = 0,
+                });
+            }
+            
+        }
         public void SendVisibilityUpdate (int index, bool doShow)
         {
             GameObject gObject = NetworkedObjectsManager.Instance.GetNetworkedGameObject(index).gameObject;
@@ -435,12 +462,16 @@ namespace Komodo.Runtime
                 menuCanvasGroup.alpha = 1;
 
                 menuCanvasGroup.blocksRaycasts = true;
+
+                SendMenuVisibilityUpdate(activeState);
             }
             else
             {
                 menuCanvasGroup.alpha = 0;
 
                 menuCanvasGroup.blocksRaycasts = false;
+
+                SendMenuVisibilityUpdate(activeState);
             }
         }
 

--- a/Komodo/Assets/Packages/KomodoCore/Runtime/Scripts/RuntimeSession/TabButton.cs
+++ b/Komodo/Assets/Packages/KomodoCore/Runtime/Scripts/RuntimeSession/TabButton.cs
@@ -50,23 +50,6 @@ namespace Komodo.Runtime
         public void Select ()
         {
             onTabSelected.Invoke();
-
-            if (gameObject.name == "Settings") 
-            {
-                ClientSpawnManager.Instance.SendMenuInteractionsType((int)INTERACTIONS.SETTING_TAB);
-            }
-            if (gameObject.name == "People") 
-            {
-                ClientSpawnManager.Instance.SendMenuInteractionsType((int)INTERACTIONS.PEOPLE_TAB);
-            }
-            if (gameObject.name == "Interact") 
-            {
-                ClientSpawnManager.Instance.SendMenuInteractionsType((int)INTERACTIONS.INTERACTION_TAB);
-            }
-            if (gameObject.name == "Create") 
-            {
-                ClientSpawnManager.Instance.SendMenuInteractionsType((int)INTERACTIONS.CREATE_TAB);
-            }
         }
 
         public void Deselect ()

--- a/Komodo/Assets/Packages/KomodoCore/Runtime/Scripts/RuntimeSession/TabButton.cs
+++ b/Komodo/Assets/Packages/KomodoCore/Runtime/Scripts/RuntimeSession/TabButton.cs
@@ -50,6 +50,23 @@ namespace Komodo.Runtime
         public void Select ()
         {
             onTabSelected.Invoke();
+
+            if (gameObject.name == "Settings") 
+            {
+                ClientSpawnManager.Instance.SendMenuInteractionsType((int)INTERACTIONS.SETTING_TAB);
+            }
+            if (gameObject.name == "People") 
+            {
+                ClientSpawnManager.Instance.SendMenuInteractionsType((int)INTERACTIONS.PEOPLE_TAB);
+            }
+            if (gameObject.name == "Interact") 
+            {
+                ClientSpawnManager.Instance.SendMenuInteractionsType((int)INTERACTIONS.INTERACTION_TAB);
+            }
+            if (gameObject.name == "Create") 
+            {
+                ClientSpawnManager.Instance.SendMenuInteractionsType((int)INTERACTIONS.CREATE_TAB);
+            }
         }
 
         public void Deselect ()

--- a/Komodo/Assets/Packages/KomodoCore/Runtime/Scripts/RuntimeSession/TabManager.cs
+++ b/Komodo/Assets/Packages/KomodoCore/Runtime/Scripts/RuntimeSession/TabManager.cs
@@ -78,14 +78,14 @@ namespace Komodo.Runtime
 
                 return;
             }
-
+        
             tab.Select();
 
             _selectedTab = tab;
 
             ResetTabs();
 
-            tab.background.sprite = tabActive;
+            tab.background.sprite = tabActive; 
         }
 
         public void ResetTabs ()

--- a/Komodo/ProjectSettings/ProjectSettings.asset
+++ b/Komodo/ProjectSettings/ProjectSettings.asset
@@ -727,7 +727,7 @@ PlayerSettings:
   metroSplashScreenUseBackgroundColor: 0
   platformCapabilities:
     WindowsStoreApps:
-      CodeGeneration: False
+      EnterpriseAuthentication: False
       OfflineMapsManagement: False
       HumanInterfaceDevice: False
       Location: False
@@ -760,10 +760,10 @@ PlayerSettings:
       PointOfService: False
       RecordedCallsFolder: False
       Contacts: False
-      Proximity: False
       InternetClient: False
+      CodeGeneration: False
       BackgroundMediaPlayback: False
-      EnterpriseAuthentication: False
+      Proximity: False
   metroTargetDeviceFamilies:
     Desktop: False
     Holographic: False


### PR DESCRIPTION
# Capture User Interactions & Fixed Desktop/VR mode menu bugs & Instructor Menu Button 

## Capture user interactions
Added several interaction types to the capture functionality. These interaction types are hide and show menu, settings tab, people tab, interact tab, and create tab. While capture is turned on, these interaction types will be registered accordingly to users' actions. 


### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Testing 
- [ ] Change that requires a documentation update

### How Has This Been Tested?
**Spectator Mode**
- Create and enter a lab. 
- Click on **Settings Tab** -> **Instructor Menu** -> **Capture**
- Once the capture has started, perform actions (clicking different tabs on the menu). You should probably remember how many times and the order when you are clicking the tabs.
- Stop the capture
- Log into our SFTP client and go to this directory **/home/komodo/captures**
- You should be able to find a folder with your captured data in it.
- You should analyze the data by checking the order of the interaction types being captured and the numbers of time that these types have occurred. 

**VR Mode**
It is advised that at least **two people** (and at least one person should be in the spectator mode) should participate in the testing for VR mode since the **Capture button is only available in the spectator mode**. 
- Create and enter a lab. Enter VR mode.
- The person who is in spectator mode should click on **Settings Tab** -> **Instructor Menu** -> **Capture**
- Once the capture has started, perform actions (clicking different tabs on the menu). You should probably remember how many times and the order when you are clicking the tabs.
- Stop the capture
- Log into our SFTP client and go to this directory **/home/komodo/captures**
- You should be able to find a folder with your captured data in it.
- You should analyze the data by checking the order of the interaction types being captured and the numbers of time that these types have occurred. 

**All information about what numbers are registered for what interaction types can be found in ClientSpawnManager.cs**

- [x] Manual Test
- [ ] Unit Test
- [ ] Integration / End-to-End Test


[Duplicate all of the above for each distinct feature / bug fix / etc.]


## Fixed Desktop/VR mode menu bug
Menu bug: When user switches from VR mode to desktop mode, the VR menu from the VR mode will replace the menu being used in desktop mode. We fixed the bug.


### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Testing 
- [ ] Change that requires a documentation update

### How Has This Been Tested?
- Open a lab with v0.5.7
- Enter VR mode
- Switch back to Desktop mode
- The expected result: the menu in desktop mode should only contain Settings, People, and Interact tabs. 

- [x] Manual Test
- [ ] Unit Test
- [ ] Integration / End-to-End Test


[Duplicate all of the above for each distinct feature / bug fix / etc.]



## Instructor Menu Button
To close the instructor menu in previous version, user needs to click the Back button from the instructor menu. We find this unnecessary. To enhance the user experience, we decided to make the Instructor Menu Button to have both **Turn On** and **Turn Off** functionalities. 


### Type of change

- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Testing 
- [ ] Change that requires a documentation update

### How Has This Been Tested?
- Open a lab with v0.5.7
- Enter Desktop mode
- Press Settings -> Instructor Menu button
- The Instructor Menu should now show up.
- Press the Instructor Menu button again.
- The Instructor Menu should be disabled. 

- [x] Manual Test
- [ ] Unit Test
- [ ] Integration / End-to-End Test


[Duplicate all of the above for each distinct feature / bug fix / etc.]
_____

# Test Configuration

* _REPLACE ME: Browser vendor and version: e.g., Chrome Version 91.0.4472.164 (Official Build) (64-bit)_
* _REPLACE ME: VR Device and OS version: e.g., Oculus Quest v29_
- [x] PC VR (Link / AirLink)
- [ ] Standalone 

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas that are not self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings 
- [ ] My changes have no unnecessary logging
- [ ] I have added tests that prove my fix is effective or that my feature works, for sufficiently complex features
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Sensitive info like tokens, secrets, and passwords have been removed before submitting

Modified from this article:
Phillip Johnston, “A GitHub Pull Request Template for Your Projects - Embedded Artistry,” Embedded Artistry, Aug. 04, 2017. https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ (accessed Jul. 22, 2021).
